### PR TITLE
Fixed quota calculation and readiness scalablity

### DIFF
--- a/kuryr_kubernetes/controller/handlers/namespace.py
+++ b/kuryr_kubernetes/controller/handlers/namespace.py
@@ -175,6 +175,7 @@ class NamespaceHandler(k8s_base.ResourceEventHandler):
     @MEMOIZE
     def _check_quota(self, quota):
         os_net = clients.get_network_client()
+        project_id = os_net.get_project_id()
         resources = {'subnets': os_net.subnets,
                      'networks': os_net.networks,
                      'security_groups': os_net.security_groups}
@@ -183,7 +184,7 @@ class NamespaceHandler(k8s_base.ResourceEventHandler):
             resource_quota = quota[resource]
             if utils.has_limit(resource_quota):
                 if not utils.is_available(resource, resource_quota,
-                                          network_func):
+                                          network_func, project_id):
                     return False
         return True
 

--- a/kuryr_kubernetes/controller/handlers/namespace.py
+++ b/kuryr_kubernetes/controller/handlers/namespace.py
@@ -174,17 +174,12 @@ class NamespaceHandler(k8s_base.ResourceEventHandler):
 
     @MEMOIZE
     def _check_quota(self, quota):
-        os_net = clients.get_network_client()
-        project_id = os_net.get_project_id()
-        resources = {'subnets': os_net.subnets,
-                     'networks': os_net.networks,
-                     'security_groups': os_net.security_groups}
+        resources = ('subnets', 'networks', 'security_groups')
 
-        for resource, network_func in resources.items():
+        for resource in resources:
             resource_quota = quota[resource]
             if utils.has_limit(resource_quota):
-                if not utils.is_available(resource, resource_quota,
-                                          network_func, project_id):
+                if not utils.is_available(resource, resource_quota):
                     return False
         return True
 

--- a/kuryr_kubernetes/controller/handlers/policy.py
+++ b/kuryr_kubernetes/controller/handlers/policy.py
@@ -150,9 +150,10 @@ class NetworkPolicyHandler(k8s_base.ResourceEventHandler):
     @MEMOIZE
     def _check_quota(self, quota):
         os_net = clients.get_network_client()
+        project_id = os_net.get_project_id()
         if utils.has_limit(quota.security_groups):
             return utils.is_available('security_groups', quota.security_groups,
-                                      os_net.security_groups)
+                                      os_net.security_groups, project_id)
         return True
 
     def _is_service_affected(self, service, affected_pods):

--- a/kuryr_kubernetes/controller/handlers/policy.py
+++ b/kuryr_kubernetes/controller/handlers/policy.py
@@ -149,11 +149,8 @@ class NetworkPolicyHandler(k8s_base.ResourceEventHandler):
 
     @MEMOIZE
     def _check_quota(self, quota):
-        os_net = clients.get_network_client()
-        project_id = os_net.get_project_id()
         if utils.has_limit(quota.security_groups):
-            return utils.is_available('security_groups', quota.security_groups,
-                                      os_net.security_groups, project_id)
+            return utils.is_available('security_groups', quota.security_groups)
         return True
 
     def _is_service_affected(self, service, affected_pods):

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -215,8 +215,9 @@ class VIFHandler(k8s_base.ResourceEventHandler):
     @MEMOIZE
     def is_ready(self, quota):
         os_net = clients.get_network_client()
+        project_id = os_net.get_project_id()
         if utils.has_limit(quota.ports):
-            return utils.is_available('ports', quota.ports, os_net.ports)
+            return utils.is_available('ports', quota.ports, os_net.ports, project_id)
         return True
 
     @staticmethod

--- a/kuryr_kubernetes/controller/handlers/vif.py
+++ b/kuryr_kubernetes/controller/handlers/vif.py
@@ -214,10 +214,8 @@ class VIFHandler(k8s_base.ResourceEventHandler):
 
     @MEMOIZE
     def is_ready(self, quota):
-        os_net = clients.get_network_client()
-        project_id = os_net.get_project_id()
         if utils.has_limit(quota.ports):
-            return utils.is_available('ports', quota.ports, os_net.ports, project_id)
+            return utils.is_available('ports', quota.ports)
         return True
 
     @staticmethod

--- a/kuryr_kubernetes/controller/managers/health.py
+++ b/kuryr_kubernetes/controller/managers/health.py
@@ -61,7 +61,7 @@ class HealthServer(object):
     def _components_ready(self):
         os_net = clients.get_network_client()
         project_id = config.CONF.neutron_defaults.project
-        quota = os_net.get_quota(project_id)
+        quota = os_net.get_quota(quota=project_id, details=True)
 
         for component in self._registry:
             if not component.is_ready(quota):

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -217,12 +217,11 @@ def extract_pod_annotation(annotation):
 
 def has_limit(quota):
     NO_LIMIT = -1
-    return quota != NO_LIMIT
+    return quota['limit'] != NO_LIMIT
 
 
-def is_available(resource, resource_quota, network_func, project_id):
-    qnt_resources = len(list(network_func(project_id=project_id)))
-    availability = resource_quota - qnt_resources
+def is_available(resource, resource_quota):
+    availability = resource_quota['limit'] - resource_quota['used']
     if availability <= 0:
         LOG.error("Quota exceeded for resource: %s", resource)
         return False

--- a/kuryr_kubernetes/utils.py
+++ b/kuryr_kubernetes/utils.py
@@ -220,8 +220,8 @@ def has_limit(quota):
     return quota != NO_LIMIT
 
 
-def is_available(resource, resource_quota, network_func):
-    qnt_resources = len(list(network_func()))
+def is_available(resource, resource_quota, network_func, project_id):
+    qnt_resources = len(list(network_func(project_id=project_id)))
     availability = resource_quota - qnt_resources
     if availability <= 0:
         LOG.error("Quota exceeded for resource: %s", resource)


### PR DESCRIPTION
The OpenShift installation guide requires the admin rights for the installer user. The admin role in openstack can list all resources within the whole domain where can be multiple projects or tenants. Such requests as 'port list' or 'security groups list' from admin users behave like this - they return all objects from the domain.

As a result, the quota calculation for ports and security groups is not accurate. It compares the project limits with domain usage, and this is not correct.
I suggest using the project_id for such a request. It will limit usage calculation by the project.

This change has another big improvement - the speedup of readiness check. Current deployments of OpenShift platform with Kuryr CNI are crashing because of kuryr-controller cannot come to READY state. The domain of openstack deployment can have a lot of projects with tones of workloads, and listing can take a lot of time. It leads to readiness checks to fail because of timeout.

The examples of domain scoped and project scoped requests:

```
>>> ports = network.ports(project_id=network.get_project_id())
>>> len(list(ports))
458
>>> ports = network.ports()
>>> len(list(ports))
10734
>>> subnets = network.subnets(project_id=network.get_project_id())
>>> len(list(ports))
57
>>> networks = network.networks(project_id=network.get_project_id())
>>> len(list(networks))
57
>>> subnets = network.subnets(project_id=network.get_project_id())
>>> subnets = network.subnets()
>>> len(list(subnets))
245
>>> networks = network.networks()
>>> len(list(networks))
245

```